### PR TITLE
fix(prometheus): handle metrics with same name but varying tags.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,7 @@ task aggregatedJacocoReport(type: JacocoReport, group: 'Coverage reports') {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: 'io/armory/plugin/observability/model/**')
+            fileTree(dir: it, exclude: 'io/micrometer/**')
         }))
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,8 @@ subprojects { subProject ->
     dependencies {
         compileOnly 'org.projectlombok:lombok:+'
         annotationProcessor 'org.projectlombok:lombok:+'
+        testCompileOnly 'org.projectlombok:lombok:+'
+        testAnnotationProcessor 'org.projectlombok:lombok:+'
 
         compileOnly(group: 'org.pf4j', name: 'pf4j', version: "${pf4jVersion}")
         compileOnly(group: 'com.netflix.spinnaker.kork', name: 'kork-plugins-api', version: "${korkVersion}")
@@ -108,6 +110,10 @@ subprojects { subProject ->
         testImplementation "com.netflix.spinnaker.kork:kork-plugins-spring-api:$korkVersion"
         testImplementation "com.netflix.spinnaker.kork:kork-core:${korkVersion}"
         testImplementation "com.netflix.spinnaker.kork:kork-web:${korkVersion}"
+        testImplementation "org.mock-server:mockserver-client-java:5.10.0"
+        testImplementation "org.mock-server:mockserver-junit-rule:5.10.0"
+        testImplementation "org.testcontainers:testcontainers:1.14.3"
+        testImplementation 'io.rest-assured:rest-assured:4.3.0'
     }
 
     group = "io.armory.plugins.metrics"

--- a/common/src/main/java/io/armory/plugin/observability/promethus/PrometheusRegistrySupplier.java
+++ b/common/src/main/java/io/armory/plugin/observability/promethus/PrometheusRegistrySupplier.java
@@ -20,7 +20,7 @@ import io.armory.plugin.observability.model.PluginConfig;
 import io.armory.plugin.observability.model.PluginMetricsPrometheusConfig;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheus.MutatedPrometheusMeterRegistry;
 import io.prometheus.client.CollectorRegistry;
 import java.util.function.Supplier;
 
@@ -43,11 +43,11 @@ public class PrometheusRegistrySupplier implements Supplier<MeterRegistry> {
   }
 
   @Override
-  public PrometheusMeterRegistry get() {
+  public MutatedPrometheusMeterRegistry get() {
     if (!prometheusConfig.isEnabled()) {
       return null;
     }
     var config = new PrometheusRegistryConfig(prometheusConfig);
-    return new PrometheusMeterRegistry(config, collectorRegistry, clock);
+    return new MutatedPrometheusMeterRegistry(config, collectorRegistry, clock);
   }
 }

--- a/common/src/main/java/io/micrometer/prometheus/MutatedPrometheusMeterRegistry.java
+++ b/common/src/main/java/io/micrometer/prometheus/MutatedPrometheusMeterRegistry.java
@@ -1,0 +1,472 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License") you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.prometheus;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.cumulative.CumulativeFunctionCounter;
+import io.micrometer.core.instrument.cumulative.CumulativeFunctionTimer;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.internal.DefaultGauge;
+import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
+import io.micrometer.core.instrument.internal.DefaultMeter;
+import io.micrometer.core.lang.Nullable;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
+import java.util.stream.Stream;
+
+public class MutatedPrometheusMeterRegistry extends MeterRegistry {
+  private final CollectorRegistry registry;
+  private final ConcurrentMap<String, MicrometerCollector> collectorMap = new ConcurrentHashMap<>();
+  private final PrometheusConfig prometheusConfig;
+
+  public MutatedPrometheusMeterRegistry(PrometheusConfig config) {
+    this(config, new CollectorRegistry(), Clock.SYSTEM);
+  }
+
+  public MutatedPrometheusMeterRegistry(
+      PrometheusConfig config, CollectorRegistry registry, Clock clock) {
+    super(clock);
+    this.registry = registry;
+    config().namingConvention(new PrometheusNamingConvention());
+    config().onMeterRemoved(this::onMeterRemoved);
+    this.prometheusConfig = config;
+  }
+
+  private static List<String> tagValues(Meter.Id id) {
+    return stream(id.getTagsAsIterable().spliterator(), false).map(Tag::getValue).collect(toList());
+  }
+
+  /**
+   * @return Content that should be included in the response body for an endpoint designated for
+   *     Prometheus to scrape from.
+   */
+  public String scrape() {
+    Writer writer = new StringWriter();
+    try {
+      scrape(writer);
+    } catch (IOException e) {
+      // This actually never happens since StringWriter::write() doesn't throw any IOException
+      throw new RuntimeException(e);
+    }
+    return writer.toString();
+  }
+
+  /**
+   * Scrape to the specified writer.
+   *
+   * @param writer Target that serves the content to be scraped by Prometheus.
+   * @throws IOException if writing fails
+   */
+  public void scrape(Writer writer) throws IOException {
+    TextFormat.write004(writer, registry.metricFamilySamples());
+  }
+
+  @Override
+  public Counter newCounter(Meter.Id id) {
+    MicrometerCollector collector = collectorByName(id);
+    PrometheusCounter counter = new PrometheusCounter(id);
+    List<String> tagValues = tagValues(id);
+
+    collector.add(
+        tagValues,
+        (conventionName, tagKeys) ->
+            Stream.of(
+                new MicrometerCollector.Family(
+                    Collector.Type.COUNTER,
+                    conventionName,
+                    new Collector.MetricFamilySamples.Sample(
+                        conventionName, tagKeys, tagValues, counter.count()))));
+
+    return counter;
+  }
+
+  @Override
+  public DistributionSummary newDistributionSummary(
+      Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
+    MicrometerCollector collector = collectorByName(id);
+    PrometheusDistributionSummary summary =
+        new PrometheusDistributionSummary(id, clock, distributionStatisticConfig, scale);
+    List<String> tagValues = tagValues(id);
+
+    collector.add(
+        tagValues,
+        (conventionName, tagKeys) -> {
+          Stream.Builder<Collector.MetricFamilySamples.Sample> samples = Stream.builder();
+
+          final ValueAtPercentile[] percentileValues = summary.takeSnapshot().percentileValues();
+          final CountAtBucket[] histogramCounts = summary.histogramCounts();
+          double count = summary.count();
+
+          if (percentileValues.length > 0) {
+            List<String> quantileKeys = new LinkedList<>(tagKeys);
+            quantileKeys.add("quantile");
+
+            // satisfies https://prometheus.io/docs/concepts/metric_types/#summary
+            for (ValueAtPercentile v : percentileValues) {
+              List<String> quantileValues = new LinkedList<>(tagValues);
+              quantileValues.add(Collector.doubleToGoString(v.percentile()));
+              samples.add(
+                  new Collector.MetricFamilySamples.Sample(
+                      conventionName, quantileKeys, quantileValues, v.value()));
+            }
+          }
+
+          Collector.Type type = Collector.Type.SUMMARY;
+          if (histogramCounts.length > 0) {
+            // Prometheus doesn't balk at a metric being BOTH a histogram and a summary
+            type = Collector.Type.HISTOGRAM;
+
+            List<String> histogramKeys = new LinkedList<>(tagKeys);
+            histogramKeys.add("le");
+
+            // satisfies https://prometheus.io/docs/concepts/metric_types/#histogram
+            for (CountAtBucket c : histogramCounts) {
+              final List<String> histogramValues = new LinkedList<>(tagValues);
+              histogramValues.add(Collector.doubleToGoString(c.bucket()));
+              samples.add(
+                  new Collector.MetricFamilySamples.Sample(
+                      conventionName + "_bucket", histogramKeys, histogramValues, c.count()));
+            }
+
+            // the +Inf bucket should always equal `count`
+            final List<String> histogramValues = new LinkedList<>(tagValues);
+            histogramValues.add("+Inf");
+            samples.add(
+                new Collector.MetricFamilySamples.Sample(
+                    conventionName + "_bucket", histogramKeys, histogramValues, count));
+          }
+
+          samples.add(
+              new Collector.MetricFamilySamples.Sample(
+                  conventionName + "_count", tagKeys, tagValues, count));
+
+          samples.add(
+              new Collector.MetricFamilySamples.Sample(
+                  conventionName + "_sum", tagKeys, tagValues, summary.totalAmount()));
+
+          return Stream.of(
+              new MicrometerCollector.Family(type, conventionName, samples.build()),
+              new MicrometerCollector.Family(
+                  Collector.Type.GAUGE,
+                  conventionName + "_max",
+                  new Collector.MetricFamilySamples.Sample(
+                      conventionName + "_max", tagKeys, tagValues, summary.max())));
+        });
+
+    return summary;
+  }
+
+  @Override
+  protected io.micrometer.core.instrument.Timer newTimer(
+      Meter.Id id,
+      DistributionStatisticConfig distributionStatisticConfig,
+      PauseDetector pauseDetector) {
+    MicrometerCollector collector = collectorByName(id);
+    PrometheusTimer timer =
+        new PrometheusTimer(id, clock, distributionStatisticConfig, pauseDetector);
+    List<String> tagValues = tagValues(id);
+
+    collector.add(
+        tagValues,
+        (conventionName, tagKeys) -> {
+          Stream.Builder<Collector.MetricFamilySamples.Sample> samples = Stream.builder();
+
+          final ValueAtPercentile[] percentileValues = timer.takeSnapshot().percentileValues();
+          final CountAtBucket[] histogramCounts = timer.histogramCounts();
+          double count = timer.count();
+
+          if (percentileValues.length > 0) {
+            List<String> quantileKeys = new LinkedList<>(tagKeys);
+            quantileKeys.add("quantile");
+
+            // satisfies https://prometheus.io/docs/concepts/metric_types/#summary
+            for (ValueAtPercentile v : percentileValues) {
+              List<String> quantileValues = new LinkedList<>(tagValues);
+              quantileValues.add(Collector.doubleToGoString(v.percentile()));
+              samples.add(
+                  new Collector.MetricFamilySamples.Sample(
+                      conventionName, quantileKeys, quantileValues, v.value(TimeUnit.SECONDS)));
+            }
+          }
+
+          Collector.Type type =
+              distributionStatisticConfig.isPublishingHistogram()
+                  ? Collector.Type.HISTOGRAM
+                  : Collector.Type.SUMMARY;
+          if (histogramCounts.length > 0) {
+            // Prometheus doesn't balk at a metric being BOTH a histogram and a summary
+            type = Collector.Type.HISTOGRAM;
+
+            List<String> histogramKeys = new LinkedList<>(tagKeys);
+            histogramKeys.add("le");
+
+            // satisfies https://prometheus.io/docs/concepts/metric_types/#histogram
+            for (CountAtBucket c : histogramCounts) {
+              final List<String> histogramValues = new LinkedList<>(tagValues);
+              histogramValues.add(Collector.doubleToGoString(c.bucket(TimeUnit.SECONDS)));
+              samples.add(
+                  new Collector.MetricFamilySamples.Sample(
+                      conventionName + "_bucket", histogramKeys, histogramValues, c.count()));
+            }
+
+            // the +Inf bucket should always equal `count`
+            final List<String> histogramValues = new LinkedList<>(tagValues);
+            histogramValues.add("+Inf");
+            samples.add(
+                new Collector.MetricFamilySamples.Sample(
+                    conventionName + "_bucket", histogramKeys, histogramValues, count));
+          }
+
+          samples.add(
+              new Collector.MetricFamilySamples.Sample(
+                  conventionName + "_count", tagKeys, tagValues, count));
+
+          samples.add(
+              new Collector.MetricFamilySamples.Sample(
+                  conventionName + "_sum", tagKeys, tagValues, timer.totalTime(TimeUnit.SECONDS)));
+
+          return Stream.of(
+              new MicrometerCollector.Family(type, conventionName, samples.build()),
+              new MicrometerCollector.Family(
+                  Collector.Type.GAUGE,
+                  conventionName + "_max",
+                  Stream.of(
+                      new Collector.MetricFamilySamples.Sample(
+                          conventionName + "_max",
+                          tagKeys,
+                          tagValues,
+                          timer.max(getBaseTimeUnit())))));
+        });
+
+    return timer;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  protected <T> io.micrometer.core.instrument.Gauge newGauge(
+      Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+    MicrometerCollector collector = collectorByName(id);
+    Gauge gauge = new DefaultGauge(id, obj, valueFunction);
+    List<String> tagValues = tagValues(id);
+
+    collector.add(
+        tagValues,
+        (conventionName, tagKeys) ->
+            Stream.of(
+                new MicrometerCollector.Family(
+                    Collector.Type.GAUGE,
+                    conventionName,
+                    new Collector.MetricFamilySamples.Sample(
+                        conventionName, tagKeys, tagValues, gauge.value()))));
+
+    return gauge;
+  }
+
+  @Override
+  protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
+    MicrometerCollector collector = collectorByName(id);
+    LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock);
+    List<String> tagValues = tagValues(id);
+
+    collector.add(
+        tagValues,
+        (conventionName, tagKeys) ->
+            Stream.of(
+                new MicrometerCollector.Family(
+                    Collector.Type.UNTYPED,
+                    conventionName,
+                    new Collector.MetricFamilySamples.Sample(
+                        conventionName + "_active_count", tagKeys, tagValues, ltt.activeTasks()),
+                    new Collector.MetricFamilySamples.Sample(
+                        conventionName + "_duration_sum",
+                        tagKeys,
+                        tagValues,
+                        ltt.duration(TimeUnit.SECONDS)))));
+
+    return ltt;
+  }
+
+  @Override
+  protected <T> FunctionTimer newFunctionTimer(
+      Meter.Id id,
+      T obj,
+      ToLongFunction<T> countFunction,
+      ToDoubleFunction<T> totalTimeFunction,
+      TimeUnit totalTimeFunctionUnit) {
+    MicrometerCollector collector = collectorByName(id);
+    FunctionTimer ft =
+        new CumulativeFunctionTimer<>(
+            id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, getBaseTimeUnit());
+    List<String> tagValues = tagValues(id);
+
+    collector.add(
+        tagValues,
+        (conventionName, tagKeys) ->
+            Stream.of(
+                new MicrometerCollector.Family(
+                    Collector.Type.SUMMARY,
+                    conventionName,
+                    new Collector.MetricFamilySamples.Sample(
+                        conventionName + "_count", tagKeys, tagValues, ft.count()),
+                    new Collector.MetricFamilySamples.Sample(
+                        conventionName + "_sum",
+                        tagKeys,
+                        tagValues,
+                        ft.totalTime(TimeUnit.SECONDS)))));
+
+    return ft;
+  }
+
+  @Override
+  protected <T> FunctionCounter newFunctionCounter(
+      Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
+    MicrometerCollector collector = collectorByName(id);
+    FunctionCounter fc = new CumulativeFunctionCounter<>(id, obj, countFunction);
+    List<String> tagValues = tagValues(id);
+
+    collector.add(
+        tagValues,
+        (conventionName, tagKeys) ->
+            Stream.of(
+                new MicrometerCollector.Family(
+                    Collector.Type.COUNTER,
+                    conventionName,
+                    new Collector.MetricFamilySamples.Sample(
+                        conventionName, tagKeys, tagValues, fc.count()))));
+
+    return fc;
+  }
+
+  @Override
+  protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
+    Collector.Type promType = Collector.Type.UNTYPED;
+    switch (type) {
+      case COUNTER:
+        promType = Collector.Type.COUNTER;
+        break;
+      case GAUGE:
+        promType = Collector.Type.GAUGE;
+        break;
+      case DISTRIBUTION_SUMMARY:
+      case TIMER:
+        promType = Collector.Type.SUMMARY;
+        break;
+    }
+
+    MicrometerCollector collector = collectorByName(id);
+    List<String> tagValues = tagValues(id);
+
+    final Collector.Type finalPromType = promType;
+    collector.add(
+        tagValues,
+        (conventionName, tagKeys) -> {
+          List<String> statKeys = new LinkedList<>(tagKeys);
+          statKeys.add("statistic");
+
+          return Stream.of(
+              new MicrometerCollector.Family(
+                  finalPromType,
+                  conventionName,
+                  stream(measurements.spliterator(), false)
+                      .map(
+                          m -> {
+                            List<String> statValues = new LinkedList<>(tagValues);
+                            statValues.add(m.getStatistic().toString());
+
+                            String name = conventionName;
+                            switch (m.getStatistic()) {
+                              case TOTAL:
+                              case TOTAL_TIME:
+                                name += "_sum";
+                                break;
+                              case MAX:
+                                name += "_max";
+                                break;
+                              case ACTIVE_TASKS:
+                                name += "_active_count";
+                                break;
+                              case DURATION:
+                                name += "_duration_sum";
+                                break;
+                            }
+
+                            return new Collector.MetricFamilySamples.Sample(
+                                name, statKeys, statValues, m.getValue());
+                          })));
+        });
+
+    return new DefaultMeter(id, type, measurements);
+  }
+
+  @Override
+  protected TimeUnit getBaseTimeUnit() {
+    return TimeUnit.SECONDS;
+  }
+
+  /** @return The underlying Prometheus {@link CollectorRegistry}. */
+  public CollectorRegistry getPrometheusRegistry() {
+    return registry;
+  }
+
+  private void onMeterRemoved(Meter meter) {
+    MicrometerCollector collector = collectorMap.get(getConventionName(meter.getId()));
+    if (collector != null) {
+      collector.remove(tagValues(meter.getId()));
+      if (collector.isEmpty()) {
+        collectorMap.remove(getConventionName(meter.getId()));
+        getPrometheusRegistry().unregister(collector);
+      }
+    }
+  }
+
+  private MicrometerCollector collectorByName(Meter.Id id) {
+    return collectorMap.compute(
+        getConventionName(id),
+        (name, existingCollector) -> {
+          List<String> tagKeys = getConventionTags(id).stream().map(Tag::getKey).collect(toList());
+          if (existingCollector != null && existingCollector.getTagKeys().equals(tagKeys)) {
+            return existingCollector;
+          }
+          return new MicrometerCollector(id, config().namingConvention(), prometheusConfig)
+              .register(registry);
+        });
+  }
+
+  @Override
+  protected DistributionStatisticConfig defaultHistogramConfig() {
+    return DistributionStatisticConfig.builder()
+        .expiry(prometheusConfig.step())
+        .build()
+        .merge(DistributionStatisticConfig.DEFAULT);
+  }
+}

--- a/common/src/test/java/io/armory/plugin/observability/prometheus/PromTsApiResponse.java
+++ b/common/src/test/java/io/armory/plugin/observability/prometheus/PromTsApiResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.armory.plugin.observability.prometheus;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class PromTsApiResponse {
+  private String status;
+  private List<Map<String, String>> data;
+}

--- a/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerFunctionalTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerFunctionalTest.java
@@ -84,6 +84,10 @@ public class PrometheusScrapeControllerFunctionalTest {
     assertEquals(expectedContent, responseEntity.getBody());
   }
 
+  /**
+   * https://github.com/armory-plugins/armory-observability-plugin/issues/3 This test ensures we can
+   * produce the desired prometheus payload.
+   */
   @Test
   public void test_that_the_prometheus_registry_can_handle_tags_that_are_sometimes_absent()
       throws Exception {

--- a/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerFunctionalTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerFunctionalTest.java
@@ -82,4 +82,15 @@ public class PrometheusScrapeControllerFunctionalTest {
         responseEntity.getHeaders().getContentType().toString());
     assertEquals(expectedContent, responseEntity.getBody());
   }
+
+  @Test
+  public void test_that_the_prometheus_registry_can_handle_tags_that_are_sometimes_absent() {
+    var tagsWithMissingTag = List.of(Tag.of("hostname", "localhost"));
+
+    var fullCollectionOfTags =
+        List.of(Tag.of("hostname", "localhost"), Tag.of("optionalExtraMetadata", "my-cool-value"));
+
+    registry.counter("foo", tagsWithMissingTag).increment();
+    registry.counter("foo", fullCollectionOfTags).increment();
+  }
 }

--- a/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerFunctionalTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerFunctionalTest.java
@@ -25,8 +25,8 @@ import io.armory.plugin.observability.promethus.PrometheusScrapeController;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.prometheus.MutatedPrometheusMeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.CollectorRegistry;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,7 +44,7 @@ import org.mockito.Mock;
 public class PrometheusScrapeControllerFunctionalTest {
 
   CollectorRegistry collectorRegistry;
-  PrometheusMeterRegistry registry;
+  MutatedPrometheusMeterRegistry registry;
 
   @Mock Clock clock;
 
@@ -56,7 +56,8 @@ public class PrometheusScrapeControllerFunctionalTest {
     collectorRegistry = new CollectorRegistry();
     sut = new PrometheusScrapeController(collectorRegistry);
 
-    registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, collectorRegistry, clock);
+    registry =
+        new MutatedPrometheusMeterRegistry(PrometheusConfig.DEFAULT, collectorRegistry, clock);
     var now = Instant.parse("2020-05-26T00:00:00.000Z");
     var later = now.plusSeconds(2);
     when(clock.monotonicTime()).thenReturn(Duration.ofMillis(now.toEpochMilli()).toNanos());
@@ -84,7 +85,16 @@ public class PrometheusScrapeControllerFunctionalTest {
   }
 
   @Test
-  public void test_that_the_prometheus_registry_can_handle_tags_that_are_sometimes_absent() {
+  public void test_that_the_prometheus_registry_can_handle_tags_that_are_sometimes_absent()
+      throws Exception {
+    var expectedScrapeResource =
+        this.getClass()
+            .getClassLoader()
+            .getResource(
+                "io/armory/plugin/observability/prometheus/expected-scrape-with-2-counters-different-tags.txt");
+
+    var expectedContent = Files.readString(Path.of(expectedScrapeResource.toURI()));
+
     var tagsWithMissingTag = List.of(Tag.of("hostname", "localhost"));
 
     var fullCollectionOfTags =
@@ -92,5 +102,13 @@ public class PrometheusScrapeControllerFunctionalTest {
 
     registry.counter("foo", tagsWithMissingTag).increment();
     registry.counter("foo", fullCollectionOfTags).increment();
+    var responseEntity = sut.scrape(null);
+    assertTrue(responseEntity.getStatusCode().is2xxSuccessful());
+    //noinspection ConstantConditions
+    assertEquals(
+        "text/plain;version=0.0.4;charset=utf-8",
+        responseEntity.getHeaders().getContentType().toString());
+    // use length since, order is non-deterministic
+    assertEquals(expectedContent.length(), responseEntity.getBody().length());
   }
 }

--- a/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerIntegrationTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerIntegrationTest.java
@@ -115,7 +115,7 @@ public class PrometheusScrapeControllerIntegrationTest {
 
     // Start Prometheus
     var container =
-        new GenericContainer("prom/prometheus:v2.10.0")
+        new GenericContainer("prom/prometheus:latest")
             .withLogConsumer(logConsumer)
             .withExposedPorts(9090)
             .withCopyFileToContainer(

--- a/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerIntegrationTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerIntegrationTest.java
@@ -127,12 +127,10 @@ public class PrometheusScrapeControllerIntegrationTest {
 
     // Make sure that prometheus was able to scrape our mocked expected controller response
     // that has 2 counters with different tag combinations
-    var it = 0;
     do {
-      log.info("sleeping");
       Thread.sleep(1000);
-      ++it;
-    } while (it != 10);
+    } while (mockServerClient.retrieveRecordedRequests(HttpRequest.request("/prometheus")).length
+        < 1);
 
     var response =
         given()

--- a/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerIntegrationTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeControllerIntegrationTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.armory.plugin.observability.prometheus;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import io.restassured.http.ContentType;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.MountableFile;
+
+public class PrometheusScrapeControllerIntegrationTest {
+
+  Logger log = LoggerFactory.getLogger(getClass());
+
+  @Rule public MockServerRule mockServerRule = new MockServerRule(this);
+
+  MockServerClient mockServerClient;
+
+  List<GenericContainer> containers;
+
+  @Before
+  public void before() {
+    containers = new LinkedList<>();
+  }
+
+  @After
+  public void after() {
+    containers.forEach(GenericContainer::stop);
+  }
+
+  /**
+   * https://github.com/armory-plugins/armory-observability-plugin/issues/3 This test ensures we
+   * prometheus can consume our expected payload.
+   */
+  @Test
+  public void
+      test_that_prometheus_can_scrape_a_payload_with_2_counters_with_that_have_the_same_name_but_different_tags()
+          throws Exception {
+    var expectedScrapeResource =
+        this.getClass()
+            .getClassLoader()
+            .getResource(
+                "io/armory/plugin/observability/prometheus/expected-scrape-with-2-counters-different-tags.txt");
+
+    var expectedContent = Files.readString(Path.of(expectedScrapeResource.toURI()));
+
+    // Stub out a mock server to return our expected Prometheus payload
+    mockServerClient
+        .when(HttpRequest.request("/prometheus"))
+        .respond(
+            HttpResponse.response(expectedContent)
+                .withHeader("Content-Type", "text/plain;version=0.0.4;charset=utf-8")
+                .withStatusCode(200));
+
+    Testcontainers.exposeHostPorts(mockServerRule.getPort());
+    var prometheusWaitStrategy =
+        new HttpWaitStrategy()
+            .forPath("/status")
+            .forPort(9090)
+            .forStatusCode(200)
+            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES));
+    Consumer<OutputFrame> logConsumer =
+        (OutputFrame outputFrame) -> log.info(outputFrame.getUtf8String());
+
+    // Create a temp file and inject the free port into the configuration
+    var promConfig = Files.createTempFile("prom-config", ".yml");
+    var promConfigTemplateResource =
+        this.getClass()
+            .getClassLoader()
+            .getResource("io/armory/plugin/observability/prometheus/prom-config-template.yml");
+    var promConfigTemplateContent = Files.readString(Path.of(promConfigTemplateResource.toURI()));
+    var processedTemplate =
+        promConfigTemplateContent.replace("@@_PORT_@@", String.valueOf(mockServerRule.getPort()));
+    Files.writeString(promConfig, processedTemplate, StandardOpenOption.WRITE);
+    assertTrue(promConfig.toFile().setReadable(true, false));
+
+    // Start Prometheus
+    var container =
+        new GenericContainer("prom/prometheus:v2.10.0")
+            .withLogConsumer(logConsumer)
+            .withExposedPorts(9090)
+            .withCopyFileToContainer(
+                MountableFile.forHostPath(promConfig), "/etc/prometheus/prometheus.yml")
+            .waitingFor(prometheusWaitStrategy)
+            .withStartupTimeout(Duration.ofSeconds(30));
+    containers.add(container);
+    container.start();
+
+    // Make sure that prometheus was able to scrape our mocked expected controller response
+    // that has 2 counters with different tag combinations
+    var it = 0;
+    do {
+      log.info("sleeping");
+      Thread.sleep(1000);
+      ++it;
+    } while (it != 10);
+
+    var response =
+        given()
+            .accept(ContentType.JSON)
+            .queryParam("match[]", "foo_total")
+            .port(container.getMappedPort(9090))
+            .when()
+            .get("/api/v1/series")
+            .as(PromTsApiResponse.class);
+
+    assertEquals("success", response.getStatus());
+    assertEquals(2, response.getData().size());
+
+    // Make sure the ts with labels hostname and optionalExtraMetadata is present with the correct
+    // values
+    var res =
+        response.getData().stream()
+            .filter(ts -> ts.containsKey("hostname") && ts.containsKey("optionalExtraMetadata"))
+            .collect(Collectors.toList());
+    assertEquals(1, res.size());
+    var data = res.get(0);
+    assertEquals("localhost", data.get("hostname"));
+    assertEquals("my-cool-value", data.get("optionalExtraMetadata"));
+
+    // Make sure the ts without the xxx is present with the correct values
+    res =
+        response.getData().stream()
+            .filter(ts -> ts.containsKey("hostname") && !ts.containsKey("optionalExtraMetadata"))
+            .collect(Collectors.toList());
+    assertEquals(1, res.size());
+    data = res.get(0);
+    assertEquals("localhost", data.get("hostname"));
+    assertNull(data.get("optionalExtraMetadata"));
+  }
+}

--- a/common/src/test/resources/io/armory/plugin/observability/prometheus/expected-scrape-with-2-counters-different-tags.txt
+++ b/common/src/test/resources/io/armory/plugin/observability/prometheus/expected-scrape-with-2-counters-different-tags.txt
@@ -1,0 +1,13 @@
+# HELP foo_total  
+# TYPE foo_total counter
+foo_total{hostname="localhost",optionalExtraMetadata="my-cool-value",} 1.0
+# HELP foo_total  
+# TYPE foo_total counter
+foo_total{hostname="localhost",} 1.0
+# HELP http_request_seconds_max  
+# TYPE http_request_seconds_max gauge
+http_request_seconds_max{response="200",uri="/foo",} 2.0
+# HELP http_request_seconds  
+# TYPE http_request_seconds summary
+http_request_seconds_count{response="200",uri="/foo",} 1.0
+http_request_seconds_sum{response="200",uri="/foo",} 2.0

--- a/common/src/test/resources/io/armory/plugin/observability/prometheus/prom-config-template.yml
+++ b/common/src/test/resources/io/armory/plugin/observability/prometheus/prom-config-template.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 1s
+
+scrape_configs:
+  - job_name: prometheus-scrape-controller-functional-test
+    metrics_path: /prometheus
+    static_configs:
+      - targets: ['host.testcontainers.internal:@@_PORT_@@']


### PR DESCRIPTION
The functional test and integration tests attached to this PR proves that https://github.com/micrometer-metrics/micrometer/issues/877#issuecomment-425102772 is no longer true.

I have temporarily copy and pasted the registry [PrometheusMeterRegistry class](https://github.com/micrometer-metrics/micrometer/blob/c9ae058383cbdb5f2ed838fabb180901ab1cf4db/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java):

I have modified the following the [offending method](https://github.com/micrometer-metrics/micrometer/blob/c9ae058383cbdb5f2ed838fabb180901ab1cf4db/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java#L404-L424) to not throw and error and registry a new entry instead: https://github.com/armory-plugins/armory-observability-plugin/blob/2819e3f6b4e2c6a8ad88fbd01511a52281c4f957/common/src/main/java/io/micrometer/prometheus/MutatedPrometheusMeterRegistry.java#L452-L463

