### PR TITLE
fix: avoid tags that are used by spinnaker services

### DIFF
--- a/common/src/main/java/io/armory/plugin/observability/service/TagsService.java
+++ b/common/src/main/java/io/armory/plugin/observability/service/TagsService.java
@@ -42,6 +42,14 @@ public class TagsService {
   private static final String SPRING_BOOT_BUILD_PROPERTIES_PATH = "META-INF/build-info.properties";
   protected static final String PLUGIN_PROPERTIES_PATH =
       "io/armory/plugin/observability/build.properties";
+  public static final String SPIN_SVC = "spinSvc";
+  public static final String ARM_SPIN_SVC_VER = "armSpinSvcVer";
+  public static final String OSS_SPIN_SVC_VER = "ossSpinSvcVer";
+  public static final String SPINNAKER_RELEASE = "spinnakerRelease";
+  public static final String HOSTNAME = "hostname";
+  public static final String LIB = "lib";
+  public static final String LIB_VER = "libVer";
+  public static final String LIB_NAME = "aop";
 
   protected final PluginMetricsConfig metricsConfig;
   private final VersionResolver versionResolver;
@@ -94,13 +102,13 @@ public class TagsService {
         .or(() -> ofNullable(versionResolver.resolve(environmentMetadata.getApplicationName())))
         .ifPresent(version -> tags.put("version", version));
 
-    tags.put("lib", "aop");
-    tags.put("libVer", environmentMetadata.getPluginVersion());
-    tags.put("spinSvc", environmentMetadata.getApplicationName());
-    tags.put("armSpinSvcVer", environmentMetadata.getArmoryAppVersion());
-    tags.put("ossSpinSvcVer", environmentMetadata.getOssAppVersion());
-    tags.put("spinnakerRelease", environmentMetadata.getSpinnakerRelease());
-    tags.put("hostname", System.getenv("HOSTNAME"));
+    tags.put(LIB, LIB_NAME);
+    tags.put(LIB_VER, environmentMetadata.getPluginVersion());
+    tags.put(SPIN_SVC, environmentMetadata.getApplicationName());
+    tags.put(ARM_SPIN_SVC_VER, environmentMetadata.getArmoryAppVersion());
+    tags.put(OSS_SPIN_SVC_VER, environmentMetadata.getOssAppVersion());
+    tags.put(SPINNAKER_RELEASE, environmentMetadata.getSpinnakerRelease());
+    tags.put(HOSTNAME, System.getenv("HOSTNAME"));
 
     return tags.entrySet().stream()
         .filter(it -> (it.getValue() != null && !it.getValue().strip().equals("")))

--- a/common/src/main/java/io/armory/plugin/observability/service/TagsService.java
+++ b/common/src/main/java/io/armory/plugin/observability/service/TagsService.java
@@ -94,11 +94,11 @@ public class TagsService {
         .or(() -> ofNullable(versionResolver.resolve(environmentMetadata.getApplicationName())))
         .ifPresent(version -> tags.put("version", version));
 
-    tags.put("lib", "armory-observability-plugin");
-    tags.put("libVersion", environmentMetadata.getPluginVersion());
-    tags.put("applicationName", environmentMetadata.getApplicationName());
-    tags.put("armoryAppVersion", environmentMetadata.getArmoryAppVersion());
-    tags.put("ossAppVersion", environmentMetadata.getOssAppVersion());
+    tags.put("lib", "aop");
+    tags.put("libVer", environmentMetadata.getPluginVersion());
+    tags.put("spinSvc", environmentMetadata.getApplicationName());
+    tags.put("armSpinSvcVer", environmentMetadata.getArmoryAppVersion());
+    tags.put("ossSpinSvcVer", environmentMetadata.getOssAppVersion());
     tags.put("spinnakerRelease", environmentMetadata.getSpinnakerRelease());
     tags.put("hostname", System.getenv("HOSTNAME"));
 

--- a/common/src/test/java/io/armory/plugin/observability/service/TagsServiceTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/service/TagsServiceTest.java
@@ -16,7 +16,7 @@
 
 package io.armory.plugin.observability.service;
 
-import static io.armory.plugin.observability.service.TagsService.PLUGIN_PROPERTIES_PATH;
+import static io.armory.plugin.observability.service.TagsService.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -96,8 +96,8 @@ public class TagsServiceTest {
                 .build());
 
     assertEquals(2, res.size());
-    assertEquals(res.get("applicationName"), "foo");
-    assertEquals(res.get("lib"), "armory-observability-plugin");
+    assertEquals(res.get(SPIN_SVC), "foo");
+    assertEquals(res.get(LIB), LIB_NAME);
   }
 
   @Test
@@ -137,10 +137,7 @@ public class TagsServiceTest {
   @Test
   public void test_that_additional_tags_are_added() {
     sut.metricsConfig.setAdditionalTags(
-        Map.of(
-            "foo", "bar",
-            "someValue", "12345",
-            "spinnakerRelease", "I will be ignored"));
+        Map.of("foo", "bar", "someValue", "12345", SPINNAKER_RELEASE, "I will be ignored"));
     var res =
         sut.getDefaultTagsAsFilteredMap(
             ArmoryEnvironmentMetadata.builder().spinnakerRelease("I take precedence").build());
@@ -148,8 +145,8 @@ public class TagsServiceTest {
     assertEquals(4, res.size());
     assertEquals("bar", res.get("foo"));
     assertEquals("12345", res.get("someValue"));
-    assertEquals("I take precedence", res.get("spinnakerRelease"));
-    assertEquals(res.get("lib"), "armory-observability-plugin");
+    assertEquals("I take precedence", res.get(SPINNAKER_RELEASE));
+    assertEquals(res.get(LIB), LIB_NAME);
   }
 
   @Test


### PR DESCRIPTION
CC: @kskewes

This is a breaking change in terms of existing dashboards.
I am having to rename the default keys to be more unique to avoid collisions.
I noticed today that Fiat was overriding applicationName as it uses that dimension/tag itself.

I am proposing the following changes:

`libVersion` -> 'libVer'
`applicationName ` -> 'spinSvc'
`armoryAppVersion ` -> 'armSpinSvcVer'
`ossAppVersion ` -> 'ossSpinSvcVer'