### PR TITLE
feat(filters): add armory recommended filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In software metrics, logging and tracing make up the core categories of observab
 
 ## Plugin Configuration
 
-### Condensed Example
+### Condensed Prometheus Example
 ```yaml
 spinnaker:
   extensibility:
@@ -38,11 +38,29 @@ spinnaker:
       Armory.ObservabilityPlugin:
         enabled: true
         config.metrics:
-          armoryRecommendedFiltersEnabled: true
           additionalTags:
             customerName: armory
             customerEnvName: production
-          prometheus.enabled: true
+          prometheus:
+            enabled: true
+            meterRegistryConfig.armoryRecommendedFiltersEnabled: true
+```
+
+### Condensed NR Example
+```yaml
+spinnaker:
+  extensibility:
+    plugins:
+      Armory.ObservabilityPlugin:
+        enabled: true
+        config.metrics:
+          additionalTags:
+            customerName: armory
+            customerEnvName: fieldju-local
+          newrelic:
+            enabled: true
+            apiKey: encrypted:secrets-manager!r:us-west-2!s:spinnaker-development-secrets!k:new-relic-insert-key
+            meterRegistryConfig.armoryRecommendedFiltersEnabled: true
 ```
 
 ### All Options (we recommend this goes in spinnaker-local.yaml)
@@ -54,14 +72,6 @@ spinnaker:
         enabled: true
         config:
           metrics:
-              # Configures an opinionated but sane set of default meter filters: https://micrometer.io/docs/concepts#_meter_filters
-              # For example we filter out controller.invocations to prefer the micrometer generated metric 'http.server.requests'
-              # See the following for more details: 
-              # https://github.com/armory-plugins/armory-observability-plugin/blob/master/common/src/main/java/io/armory/plugin/observability/filters/ArmoryRecommendedFilters.java
-              # https://github.com/armory-plugins/armory-observability-plugin/blob/master/common/src/main/java/io/armory/plugin/observability/filters/Filters.java
-              # See bottom of config for controlling percentiles
-              # Optional, Default: false
-              armoryRecommendedFiltersEnabled: true
               # Key value map of extra static default tags to add when generated the default tags
               # Optional, Default: empty map
               additionalTags:
@@ -74,11 +84,7 @@ spinnaker:
                   # Halyard generated UUID for non-managed and non-sass customers
                   # Optional, Default: omitted from default tags
                   customerEnvId: e0fb0422-aa8e-11ea-bb37-0242ac130002
-              
-              # By default this plugin adds a set of sane default tags to help with observability best practices, you can disable those here
-              # Optional, Default: false
-              defaultTagsDisabled: false
-    
+
               # Creates an actuator endpoint for prometheus with id = 'aop-prometheus'
               # See the bottom of this config block
               #
@@ -108,6 +114,19 @@ spinnaker:
                 # Turn this off to minimize the amount of data sent on each scrape.
                 # Optional, Default: false
                 descriptions: false
+                meterRegistryConfig: 
+                    # By default this plugin adds a set of sane default tags to help with observability best practices, you can disable those here
+                    # Optional, Default: false
+                    defaultTagsDisabled: false
+                    # Config related to configuring, filtering, and transforming Micrometer meters
+                    # Configures an opinionated but sane set of default meter filters: https://micrometer.io/docs/concepts#_meter_filters
+                    # For example we filter out controller.invocations to prefer the micrometer generated metric 'http.server.requests'
+                    # See the following for more details: 
+                    # https://github.com/armory-plugins/armory-observability-plugin/blob/master/common/src/main/java/io/armory/plugin/observability/filters/ArmoryRecommendedFilters.java
+                    # https://github.com/armory-plugins/armory-observability-plugin/blob/master/common/src/main/java/io/armory/plugin/observability/filters/Filters.java
+                    # See bottom of config for controlling percentiles
+                    # Optional, Default: false
+                    armoryRecommendedFiltersEnabled: true
         
               newrelic:
                 # Optional, Default: false
@@ -131,7 +150,20 @@ spinnaker:
                 # The number of measurements per request to use for the backend. If more
                 # measurements are found, then multiple requests will be made.
                 # Optional, Default: 10000
-                batchSize: 10000 
+                batchSize: 10000
+                meterRegistryConfig: 
+                    # By default this plugin adds a set of sane default tags to help with observability best practices, you can disable those here
+                    # Optional, Default: false
+                    defaultTagsDisabled: false
+                    # Config related to configuring, filtering, and transforming Micrometer meters
+                    # Configures an opinionated but sane set of default meter filters: https://micrometer.io/docs/concepts#_meter_filters
+                    # For example we filter out controller.invocations to prefer the micrometer generated metric 'http.server.requests'
+                    # See the following for more details: 
+                    # https://github.com/armory-plugins/armory-observability-plugin/blob/master/common/src/main/java/io/armory/plugin/observability/filters/ArmoryRecommendedFilters.java
+                    # https://github.com/armory-plugins/armory-observability-plugin/blob/master/common/src/main/java/io/armory/plugin/observability/filters/Filters.java
+                    # See bottom of config for controlling percentiles
+                    # Optional, Default: false
+                    armoryRecommendedFiltersEnabled: true
     repositories:
       armory-observability-plugin-releases:
         url: https://raw.githubusercontent.com/armory-plugins/armory-observability-plugin-releases/master/repositories.json

--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ spinnaker:
       Armory.ObservabilityPlugin:
         enabled: true
         config.metrics:
+          armoryRecommendedFiltersEnabled: true
           additionalTags:
             customerName: armory
             customerEnvName: production
           prometheus.enabled: true
 ```
 
-### All Options
+### All Options (we recommend this goes in spinnaker-local.yaml)
 ```yaml
 spinnaker:
   extensibility:
@@ -53,6 +54,14 @@ spinnaker:
         enabled: true
         config:
           metrics:
+              # Configures an opinionated but sane set of default meter filters: https://micrometer.io/docs/concepts#_meter_filters
+              # For example we filter out controller.invocations to prefer the micrometer generated metric 'http.server.requests'
+              # See the following for more details: 
+              # https://github.com/armory-plugins/armory-observability-plugin/blob/master/common/src/main/java/io/armory/plugin/observability/filters/ArmoryRecommendedFilters.java
+              # https://github.com/armory-plugins/armory-observability-plugin/blob/master/common/src/main/java/io/armory/plugin/observability/filters/Filters.java
+              # See bottom of config for controlling percentiles
+              # Optional, Default: false
+              armoryRecommendedFiltersEnabled: true
               # Key value map of extra static default tags to add when generated the default tags
               # Optional, Default: empty map
               additionalTags:
@@ -129,6 +138,11 @@ spinnaker:
 # The prometheus integration utilizes the actuator system therefore it is partially configured under the management settings
 # See: https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html for more details 
 management:
+  # Percentiles for http.server.requests are off by default, if you want them you can add them here
+  # When you add these, they will generate extra metrics with percentile = 'xxx' as a tag under
+  metrics.distribution:
+      percentiles[http.server.requests]: 0.95, 0.99
+      percentiles-histogram[http.server.requests]: true
   endpoints.web:
     exposure.include: health,info,aop-prometheus
     # You can override the path for any actuator endpoint

--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,3 @@
-
-import com.netflix.spinnaker.gradle.codestyle.SpinnakerCodeStylePlugin
-
-buildscript {
-    repositories {
-        maven {
-            url "https://dl.bintray.com/spinnaker/gradle"
-        }
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-
-    dependencies {
-        classpath 'com.netflix.spinnaker.gradle:spinnaker-dev-plugin:7.1.2'
-    }
-}
-
 plugins {
     id("com.palantir.git-version").version("0.12.2")
     id("io.spinnaker.plugin.bundler").version("$spinnakerGradleVersion")
@@ -53,7 +35,6 @@ allprojects {
 subprojects { subProject ->
     apply plugin: 'java'
     apply plugin: "maven-publish"
-    apply plugin: SpinnakerCodeStylePlugin
 
     if (!['common'].contains(subProject.name)) {
         apply plugin: "io.spinnaker.plugin.service-extension"

--- a/common/src/main/java/io/armory/plugin/observability/filters/ArmoryRecommendedFilters.java
+++ b/common/src/main/java/io/armory/plugin/observability/filters/ArmoryRecommendedFilters.java
@@ -1,0 +1,19 @@
+package io.armory.plugin.observability.filters;
+
+import static io.armory.plugin.observability.filters.Filters.*;
+
+import io.micrometer.core.instrument.config.MeterFilter;
+import java.util.List;
+
+public class ArmoryRecommendedFilters {
+
+  /*
+   * Curated list of filters/transformations that Armory uses internally to reduce DPM / metrics TS cardinality.
+   * This list is not guaranteed to have backwards compatibility with Sym versioning of the plugin.
+   * What I mean by that is that I will add and remove things to this list that you might rely on without major versioning the plugin.
+   *
+   * TODO implement pattern that allows for users to pick and choose named filters and not rely on the curated list.
+   */
+  public static List<MeterFilter> ARMORY_RECOMMENDED_FILTERS =
+      List.of(DENY_CONTROLLER_INVOCATIONS_METRICS);
+}

--- a/common/src/main/java/io/armory/plugin/observability/filters/Filters.java
+++ b/common/src/main/java/io/armory/plugin/observability/filters/Filters.java
@@ -1,0 +1,26 @@
+package io.armory.plugin.observability.filters;
+
+import io.micrometer.core.instrument.config.MeterFilter;
+
+public class Filters {
+
+  /*
+   * Removes the spinnaker created 'controller.invocations' metric to prefer the micrometer created 'http.server.requests' metric
+   * They both contain http metrics, however http.server.requests is non-java / sb specific and allows for dashboards that can interoperate x-framework
+   * In addition http.server.requests doesn't stuff percentiles as tags leading to confusing queries and extra cardinality / dpm usage.
+   *
+   * https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-spring-mvc
+   *
+   * Extra details are off by default and opt in, see
+   * The preferred way to add percentiles, percentile histograms, and SLA boundaries is to apply the general purpose property-based meter filter mechanism to this timer:
+   *
+   *   management.metrics.distribution:
+   *       percentiles[http.server.requests]: 0.95, 0.99
+   *       percentiles-histogram[http.server.requests]: true (1)
+   *       sla[http.server.requests]: 10ms, 100ms
+   *
+   * See: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#per-meter-properties
+   */
+  static final MeterFilter DENY_CONTROLLER_INVOCATIONS_METRICS =
+      MeterFilter.denyNameStartsWith("controller.invocations");
+}

--- a/common/src/main/java/io/armory/plugin/observability/filters/Filters.java
+++ b/common/src/main/java/io/armory/plugin/observability/filters/Filters.java
@@ -7,20 +7,20 @@ public class Filters {
   /*
    * Removes the spinnaker created 'controller.invocations' metric to prefer the micrometer created 'http.server.requests' metric
    * They both contain http metrics, however http.server.requests is non-java / sb specific and allows for dashboards that can interoperate x-framework
-   * In addition http.server.requests doesn't stuff percentiles as tags leading to confusing queries and extra cardinality / dpm usage.
    *
    * https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-spring-mvc
    *
-   * Extra details are off by default and opt in, see
-   * The preferred way to add percentiles, percentile histograms, and SLA boundaries is to apply the general purpose property-based meter filter mechanism to this timer:
+   * Extra details are off by default and opt in
+   * The preferred way to add percentiles, percentile histograms, and SLA boundaries is to apply the general
+   * purpose property-based meter filter mechanism to this timer:
    *
-   *   management.metrics.distribution:
-   *       percentiles[http.server.requests]: 0.95, 0.99
-   *       percentiles-histogram[http.server.requests]: true (1)
-   *       sla[http.server.requests]: 10ms, 100ms
+   * management.metrics.distribution:
+   *  percentiles[http.server.requests]: 0.95, 0.99
+   *  percentiles-histogram[http.server.requests]: true
+   *  sla[http.server.requests]: 10ms, 100ms
    *
    * See: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#per-meter-properties
    */
-  static final MeterFilter DENY_CONTROLLER_INVOCATIONS_METRICS =
+  public static final MeterFilter DENY_CONTROLLER_INVOCATIONS_METRICS =
       MeterFilter.denyNameStartsWith("controller.invocations");
 }

--- a/common/src/main/java/io/armory/plugin/observability/model/BaseMetricsIntegrationConfig.java
+++ b/common/src/main/java/io/armory/plugin/observability/model/BaseMetricsIntegrationConfig.java
@@ -1,0 +1,8 @@
+package io.armory.plugin.observability.model;
+
+import lombok.Data;
+
+@Data
+public abstract class BaseMetricsIntegrationConfig {
+  private MeterRegistryConfig meterRegistryConfig = new MeterRegistryConfig();
+}

--- a/common/src/main/java/io/armory/plugin/observability/model/MeterRegistryConfig.java
+++ b/common/src/main/java/io/armory/plugin/observability/model/MeterRegistryConfig.java
@@ -1,0 +1,15 @@
+package io.armory.plugin.observability.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MeterRegistryConfig {
+  private boolean armoryRecommendedFiltersEnabled = false;
+  private boolean defaultTagsDisabled = false;
+}

--- a/common/src/main/java/io/armory/plugin/observability/model/PluginMetricsConfig.java
+++ b/common/src/main/java/io/armory/plugin/observability/model/PluginMetricsConfig.java
@@ -26,5 +26,6 @@ public class PluginMetricsConfig {
   private PluginMetricsPrometheusConfig prometheus = new PluginMetricsPrometheusConfig();
   private PluginMetricsNewRelicConfig newrelic = new PluginMetricsNewRelicConfig();
 
-  private boolean defaultTagsDisabled;
+  private boolean defaultTagsDisabled = false;
+  private boolean armoryRecommendedFiltersEnabled = false;
 }

--- a/common/src/main/java/io/armory/plugin/observability/model/PluginMetricsNewRelicConfig.java
+++ b/common/src/main/java/io/armory/plugin/observability/model/PluginMetricsNewRelicConfig.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PluginMetricsNewRelicConfig {
+public class PluginMetricsNewRelicConfig extends BaseMetricsIntegrationConfig {
   // New Relic Specific Settings
   @Builder.Default private boolean enabled = false;
   @Builder.Default private String apiKey = null;

--- a/common/src/main/java/io/armory/plugin/observability/model/PluginMetricsPrometheusConfig.java
+++ b/common/src/main/java/io/armory/plugin/observability/model/PluginMetricsPrometheusConfig.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PluginMetricsPrometheusConfig {
+public class PluginMetricsPrometheusConfig extends BaseMetricsIntegrationConfig {
   @Builder.Default private boolean enabled = false;
   @Builder.Default private int stepInSeconds = 30;
   @Builder.Default private boolean descriptions = false;

--- a/common/src/main/java/io/armory/plugin/observability/registry/AddDefaultTagsRegistryCustomizer.java
+++ b/common/src/main/java/io/armory/plugin/observability/registry/AddDefaultTagsRegistryCustomizer.java
@@ -16,13 +16,13 @@
 
 package io.armory.plugin.observability.registry;
 
+import io.armory.plugin.observability.model.MeterRegistryConfig;
 import io.armory.plugin.observability.service.TagsService;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 
 @Slf4j
-public class AddDefaultTagsRegistryCustomizer implements MeterRegistryCustomizer<MeterRegistry> {
+public class AddDefaultTagsRegistryCustomizer implements RegistryCustomizer {
 
   private final TagsService tagsService;
 
@@ -31,7 +31,11 @@ public class AddDefaultTagsRegistryCustomizer implements MeterRegistryCustomizer
   }
 
   @Override
-  public void customize(MeterRegistry registry) {
+  public void customize(MeterRegistry registry, MeterRegistryConfig meterRegistryConfig) {
+    if (meterRegistryConfig.isDefaultTagsDisabled()) {
+      return;
+    }
+
     log.info("Adding default tags to registry: {}", registry.getClass().getSimpleName());
     registry.config().commonTags(tagsService.getDefaultTags());
   }

--- a/common/src/main/java/io/armory/plugin/observability/registry/AddFiltersRegistryCustomizer.java
+++ b/common/src/main/java/io/armory/plugin/observability/registry/AddFiltersRegistryCustomizer.java
@@ -16,13 +16,13 @@
 
 package io.armory.plugin.observability.registry;
 
+import io.armory.plugin.observability.model.MeterRegistryConfig;
 import io.armory.plugin.observability.service.MeterFilterService;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 
 @Slf4j
-public class AddFiltersRegistryCustomizer implements MeterRegistryCustomizer<MeterRegistry> {
+public class AddFiltersRegistryCustomizer implements RegistryCustomizer {
 
   private final MeterFilterService meterFilterService;
 
@@ -31,10 +31,10 @@ public class AddFiltersRegistryCustomizer implements MeterRegistryCustomizer<Met
   }
 
   @Override
-  public void customize(MeterRegistry registry) {
+  public void customize(MeterRegistry registry, MeterRegistryConfig meterRegistryConfig) {
     log.info("Adding Meter Filters to registry: {}", registry.getClass().getSimpleName());
     meterFilterService
-        .getMeterFilters()
+        .getMeterFilters(meterRegistryConfig)
         .forEach(meterFilter -> registry.config().meterFilter(meterFilter));
   }
 }

--- a/common/src/main/java/io/armory/plugin/observability/registry/RegistryConfigWrapper.java
+++ b/common/src/main/java/io/armory/plugin/observability/registry/RegistryConfigWrapper.java
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-package io.armory.plugin.observability.model;
+package io.armory.plugin.observability.registry;
 
-import java.util.Map;
+import io.armory.plugin.observability.model.MeterRegistryConfig;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
-public class PluginMetricsConfig {
-  private Map<String, String> additionalTags = Map.of();
-
-  private PluginMetricsPrometheusConfig prometheus = new PluginMetricsPrometheusConfig();
-  private PluginMetricsNewRelicConfig newrelic = new PluginMetricsNewRelicConfig();
-
-  private boolean armoryRecommendedFiltersEnabled = false;
+@Builder
+public class RegistryConfigWrapper {
+  private MeterRegistry meterRegistry;
+  @Builder.Default private MeterRegistryConfig meterRegistryConfig = new MeterRegistryConfig();
 }

--- a/common/src/main/java/io/armory/plugin/observability/registry/RegistryCustomizer.java
+++ b/common/src/main/java/io/armory/plugin/observability/registry/RegistryCustomizer.java
@@ -1,0 +1,16 @@
+package io.armory.plugin.observability.registry;
+
+import io.armory.plugin.observability.model.MeterRegistryConfig;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@FunctionalInterface
+public interface RegistryCustomizer {
+
+  /**
+   * Customize the given {@code registry}.
+   *
+   * @param registry the registry to customize
+   * @param meterRegistryConfig the filter/tag config for the registry/integration being customized.
+   */
+  void customize(MeterRegistry registry, MeterRegistryConfig meterRegistryConfig);
+}

--- a/common/src/main/java/io/armory/plugin/observability/service/MeterFilterService.java
+++ b/common/src/main/java/io/armory/plugin/observability/service/MeterFilterService.java
@@ -16,6 +16,8 @@
 
 package io.armory.plugin.observability.service;
 
+import static io.armory.plugin.observability.filters.ArmoryRecommendedFilters.ARMORY_RECOMMENDED_FILTERS;
+
 import io.armory.plugin.observability.model.PluginConfig;
 import io.armory.plugin.observability.model.PluginMetricsConfig;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -43,6 +45,9 @@ public class MeterFilterService {
    * @return The list of enabled filters.
    */
   public List<MeterFilter> getMeterFilters() {
+    if (metricsConfig.isArmoryRecommendedFiltersEnabled()) {
+      return ARMORY_RECOMMENDED_FILTERS;
+    }
     return List.of();
   }
 }

--- a/common/src/main/java/io/armory/plugin/observability/service/MeterFilterService.java
+++ b/common/src/main/java/io/armory/plugin/observability/service/MeterFilterService.java
@@ -18,8 +18,7 @@ package io.armory.plugin.observability.service;
 
 import static io.armory.plugin.observability.filters.ArmoryRecommendedFilters.ARMORY_RECOMMENDED_FILTERS;
 
-import io.armory.plugin.observability.model.PluginConfig;
-import io.armory.plugin.observability.model.PluginMetricsConfig;
+import io.armory.plugin.observability.model.MeterRegistryConfig;
 import io.micrometer.core.instrument.config.MeterFilter;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -33,19 +32,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MeterFilterService {
 
-  private final PluginMetricsConfig metricsConfig;
-
-  public MeterFilterService(PluginConfig pluginConfig) {
-    metricsConfig = pluginConfig.getMetrics();
-  }
-
   /**
    * TODO, pattern for impl TBD.
    *
    * @return The list of enabled filters.
+   * @param meterRegistryConfig
    */
-  public List<MeterFilter> getMeterFilters() {
-    if (metricsConfig.isArmoryRecommendedFiltersEnabled()) {
+  public List<MeterFilter> getMeterFilters(MeterRegistryConfig meterRegistryConfig) {
+    if (meterRegistryConfig.isArmoryRecommendedFiltersEnabled()) {
+      log.info("Armory Recommended filters are enabled returning those");
       return ARMORY_RECOMMENDED_FILTERS;
     }
     return List.of();

--- a/common/src/main/java/io/armory/plugin/observability/service/TagsService.java
+++ b/common/src/main/java/io/armory/plugin/observability/service/TagsService.java
@@ -182,9 +182,6 @@ public class TagsService {
   }
 
   public List<Tag> getDefaultTags() {
-    if (metricsConfig.isDefaultTagsDisabled()) {
-      return List.of();
-    }
     var springbootPropertiesPath = getPropertiesPath();
     var buildProperties = getBuildProperties(springbootPropertiesPath);
     var pluginPropertiesPath = getPluginPropertiesPath();

--- a/common/src/test/java/io/armory/plugin/observability/registry/AddDefaultTagsRegistryCustomizerTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/registry/AddDefaultTagsRegistryCustomizerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import io.armory.plugin.observability.model.MeterRegistryConfig;
 import io.armory.plugin.observability.service.TagsService;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -50,7 +51,16 @@ public class AddDefaultTagsRegistryCustomizerTest {
   public void test_that_customize_adds_the_tags_to_the_registry_common_tag_config() {
     var tags = List.of(Tag.of("FOO", "BAR"));
     when(tagsService.getDefaultTags()).thenReturn(tags);
-    sut.customize(registry);
+    sut.customize(registry, MeterRegistryConfig.builder().build());
     verify(config, times(1)).commonTags(tags);
+  }
+
+  @Test
+  public void
+      test_that_customize_does_not_adds_the_tags_to_the_registry_common_tag_config_when_disabled() {
+    var tags = List.of(Tag.of("FOO", "BAR"));
+    when(tagsService.getDefaultTags()).thenReturn(tags);
+    sut.customize(registry, MeterRegistryConfig.builder().defaultTagsDisabled(true).build());
+    verify(config, times(0)).commonTags(tags);
   }
 }

--- a/common/src/test/java/io/armory/plugin/observability/registry/AddFiltersRegistryCustomizerTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/registry/AddFiltersRegistryCustomizerTest.java
@@ -19,6 +19,7 @@ package io.armory.plugin.observability.registry;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import io.armory.plugin.observability.model.MeterRegistryConfig;
 import io.armory.plugin.observability.service.MeterFilterService;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -47,8 +48,8 @@ public class AddFiltersRegistryCustomizerTest {
   @Test
   public void test_that_customize_adds_the_enabled_filters_to_the_registry() throws Exception {
     var denyAllFilter = MeterFilter.deny(id -> true);
-    when(meterFilterService.getMeterFilters()).thenReturn(List.of(denyAllFilter));
-    sut.customize(registry);
+    when(meterFilterService.getMeterFilters(any())).thenReturn(List.of(denyAllFilter));
+    sut.customize(registry, MeterRegistryConfig.builder().build());
     verify(config, times(1)).meterFilter(denyAllFilter);
   }
 }

--- a/common/src/test/java/io/armory/plugin/observability/service/MeterFilterServiceTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/service/MeterFilterServiceTest.java
@@ -18,8 +18,9 @@ package io.armory.plugin.observability.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-import io.armory.plugin.observability.model.PluginConfig;
+import io.armory.plugin.observability.model.MeterRegistryConfig;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,13 +30,23 @@ public class MeterFilterServiceTest {
 
   @Before
   public void before() {
-    sut = new MeterFilterService(new PluginConfig());
+    sut = new MeterFilterService();
   }
 
   @Test
-  public void test_that_getMeterFilters_returns_emtpy_list_because_it_is_not_implemented() {
-    var filters = sut.getMeterFilters();
+  public void test_that_getMeterFilters_returns_emtpy_list_by_default() {
+    var filters = sut.getMeterFilters(MeterRegistryConfig.builder().build());
     assertNotNull(filters);
     assertEquals(0, filters.size());
+  }
+
+  @Test
+  public void
+      test_that_getMeterFilters_returns_a_non_empty_list_of_filters_when_armory_recommendations_are_enabled() {
+    var filters =
+        sut.getMeterFilters(
+            MeterRegistryConfig.builder().armoryRecommendedFiltersEnabled(true).build());
+    assertNotNull(filters);
+    assertTrue(filters.size() > 0);
   }
 }

--- a/common/src/test/java/io/armory/plugin/observability/service/TagsServiceTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/service/TagsServiceTest.java
@@ -172,14 +172,6 @@ public class TagsServiceTest {
   }
 
   @Test
-  public void test_that_getDefaultTags_returns_empty_list_when_disabled() {
-    pluginConfig.getMetrics().setDefaultTagsDisabled(true);
-    var tags = sut.getDefaultTags();
-    assertNotNull(tags);
-    assertEquals(0, tags.size());
-  }
-
-  @Test
   public void test_that_getDefaultTags_returns_some_tags_even_when_no_props_are_loaded() {
     var tags = sut.getDefaultTags();
     assertNotNull(tags);


### PR DESCRIPTION
Adding our first filter to filter out controller.invocations


Removes the spinnaker created `controller.invocations` metric to prefer the micrometer created `http.server.requests` metric 
They both contain http metrics, however `http.server.requests` is non-java / sb specific and allows for dashboards that can interoperate x-framework

https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-spring-mvc

Extra details are off by default and opt in, see https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#per-meter-properties