### PR TITLE
feat(metrics): enable legacy Spectator meter registry when zero aop registries are enabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ spinnaker:
             meterRegistryConfig.armoryRecommendedFiltersEnabled: true
 ```
 
+### Example for making existing <= 1.19.x dashboards work through spectator and the monitoring daemon
+```yaml
+spinnaker.extensibility:
+  plugins:
+    Armory.ObservabilityPlugin:
+      enabled: true
+  repositories:
+    armory-observability-plugin-releases:
+      url: https://raw.githubusercontent.com/armory-plugins/armory-observability-plugin-releases/master/repositories.json
+```
+
 ### All Options (we recommend this goes in spinnaker-local.yaml)
 ```yaml
 spinnaker:

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ task aggregatedJacocoReport(type: JacocoReport, group: 'Coverage reports') {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: 'io/armory/plugin/observability/model/**')
             fileTree(dir: it, exclude: 'io/micrometer/**')
+            fileTree(dir: it, exclude: 'com/netflix/**')
         }))
     }
 }

--- a/common/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorMeterRegistry.java
+++ b/common/src/main/java/com/netflix/spinnaker/kork/metrics/SpectatorMeterRegistry.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.kork.metrics;
+
+import com.netflix.spectator.api.Registry;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Ported from https://github.com/spinnaker/kork/pull/592/files#diff-7c7f5998e2f44342a3fadd71e2b7020e so that
+ * Existing dashboards from <= 1.19 will continue to work.
+ */
+public class SpectatorMeterRegistry extends SimpleMeterRegistry {
+
+    private Registry spectatorRegistry;
+
+    public SpectatorMeterRegistry(Registry spectatorRegistry) {
+        this.spectatorRegistry = spectatorRegistry;
+    }
+
+    @Override
+    public List<Meter> getMeters() {
+        return Stream.concat(
+                spectatorRegistry.stream().map(this::convertMeter), super.getMeters().stream())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void forEachMeter(Consumer<? super Meter> consumer) {
+        Stream.concat(spectatorRegistry.stream().map(this::convertMeter), super.getMeters().stream())
+                .forEach(consumer);
+    }
+
+    public Meter convertMeter(com.netflix.spectator.api.Meter meter) {
+        final Meter.Id id = getId(meter);
+        return new Meter() {
+
+            @Override
+            public Iterable<Measurement> measure() {
+                Iterator<Measurement> measurements =
+                        StreamSupport.stream(meter.measure().spliterator(), false)
+                                .map(m -> new Measurement(m::value, Statistic.UNKNOWN))
+                                .iterator();
+                return () -> measurements;
+            }
+
+            @Override
+            public Id getId() {
+                return id;
+            }
+        };
+    }
+
+    private Meter.Id getId(com.netflix.spectator.api.Meter meter) {
+        Iterator<Tag> tags =
+                StreamSupport.stream(meter.id().tags().spliterator(), false)
+                        .map(t -> Tag.of(t.key(), t.value()))
+                        .iterator();
+        return new Meter.Id(meter.id().name(), Tags.of(() -> tags), null, "", getMeterType(meter));
+    }
+
+    private Meter.Type getMeterType(com.netflix.spectator.api.Meter meter) {
+        if (meter instanceof Counter) {
+            return Meter.Type.COUNTER;
+        } else if (meter instanceof Gauge) {
+            return Meter.Type.GAUGE;
+        } else if (meter instanceof LongTaskTimer) {
+            return Meter.Type.LONG_TASK_TIMER;
+        } else if (meter instanceof Timer) {
+            return Meter.Type.TIMER;
+        } else if (meter instanceof DistributionSummary) {
+            return Meter.Type.DISTRIBUTION_SUMMARY;
+        } else {
+            return Meter.Type.OTHER;
+        }
+    }
+}

--- a/common/src/main/java/io/armory/plugin/observability/model/MeterRegistryConfig.java
+++ b/common/src/main/java/io/armory/plugin/observability/model/MeterRegistryConfig.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MeterRegistryConfig {
-  private boolean armoryRecommendedFiltersEnabled = false;
-  private boolean defaultTagsDisabled = false;
+  @Builder.Default private boolean armoryRecommendedFiltersEnabled = false;
+  @Builder.Default private boolean defaultTagsDisabled = false;
 }

--- a/common/src/main/java/io/armory/plugin/observability/model/PluginMetricsNewRelicConfig.java
+++ b/common/src/main/java/io/armory/plugin/observability/model/PluginMetricsNewRelicConfig.java
@@ -18,10 +18,12 @@ package io.armory.plugin.observability.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/common/src/main/java/io/armory/plugin/observability/registry/ArmoryObservabilityCompositeRegistry.java
+++ b/common/src/main/java/io/armory/plugin/observability/registry/ArmoryObservabilityCompositeRegistry.java
@@ -18,12 +18,12 @@ package io.armory.plugin.observability.registry;
 
 import static java.util.Optional.ofNullable;
 
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spinnaker.kork.metrics.SpectatorMeterRegistry;
 import io.armory.plugin.observability.model.MeterRegistryConfig;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleConfig;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -57,8 +57,8 @@ public class ArmoryObservabilityCompositeRegistry extends CompositeMeterRegistry
                   // default to the simple registry and assume that Spectator with the spinnaker
                   // monitoring daemon will be used.
                   if (enabledRegistries.size() == 0) {
-                    log.warn("None of the supported Armory Observability Plugin registries where enabled defaulting a Simple Meter Registry which Spectator will use.");
-                    enabledRegistries = List.of(new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock));
+                    log.warn("None of the supported Armory Observability Plugin registries where enabled defaulting a Spectator Meter Registry which Spectator will use and is compatible with the legacy Spinnaker Monitoring Daemon 3rd party dashboards.");
+                    enabledRegistries = List.of(new SpectatorMeterRegistry(new DefaultRegistry(com.netflix.spectator.api.Clock.SYSTEM)));
                   }
                   return enabledRegistries;
                 })

--- a/common/src/test/java/io/armory/plugin/observability/registry/ArmoryObservabilityCompositeRegistryTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/registry/ArmoryObservabilityCompositeRegistryTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import com.netflix.spinnaker.kork.metrics.SpectatorMeterRegistry;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -52,11 +53,11 @@ public class ArmoryObservabilityCompositeRegistryTest {
 
   @Test
   public void
-      test_that_ArmoryObservabilityCompositeRegistry_uses_a_simple_registry_when_no_registries_are_enabled() {
+      test_that_ArmoryObservabilityCompositeRegistry_uses_a_spectator_meter_registry_when_no_registries_are_enabled() {
     var sut =
         new ArmoryObservabilityCompositeRegistry(Clock.SYSTEM, List.of(() -> null), List.of());
     assertEquals(1, sut.getRegistries().size());
-    assertEquals(SimpleMeterRegistry.class, sut.getRegistries().toArray()[0].getClass());
+    assertEquals(SpectatorMeterRegistry.class, sut.getRegistries().toArray()[0].getClass());
   }
 
   @Test


### PR DESCRIPTION
In PR: https://github.com/spinnaker/kork/pull/592 which BTW makes this plugin feasible was merged, it deleted the following file:

https://github.com/spinnaker/kork/pull/592/files#diff-7c7f5998e2f44342a3fadd71e2b7020e and made Kork default to a [MicroMeterRegistry](https://github.com/Netflix/spectator/blob/master/spectator-reg-micrometer/src/main/java/com/netflix/spectator/micrometer/MicrometerRegistry.java#L75-L88)

This inadvertently was a breaking change in terms of using the [Spinnaker Monitoring Daemon](https://github.com/spinnaker/spinnaker-monitoring) and the [existing 3rd party dashboards](https://github.com/spinnaker/spinnaker-monitoring/tree/master/spinnaker-monitoring-third-party/third_party)

This PR brings back the Spectator Meter Registry and enables it if no other AOP registry integration is enabled.

ex:

```yaml
spinnaker.extensibility:
  plugins:
    Armory.ObservabilityPlugin:
      enabled: true
  repositories:
    armory-observability-plugin-releases:
      url: https://raw.githubusercontent.com/armory-plugins/armory-observability-plugin-releases/master/repositories.json
```