### PR TITLE
fix(release): bump latest version of Kork

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.parallel=true
 
-spinnakerGradleVersion=8.0.4
+spinnakerGradleVersion=8.10.0
 pf4jVersion=3.2.0
-korkVersion=7.43.6
+korkVersion=7.81.0
 
 # TODO figure this out (hint, we need the following: https://github.com/spinnaker/kork/pull/592/files)
 clouddriverMinimumSuppotedVersion=0.0.0


### PR DESCRIPTION
Update kork to latest.
the Observability plugin seems to work with Java 11 so I think it will be fine for 1.23