### PR TITLE
docs(monitoring): Update Prometheus Mixin location

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ spinnaker:
             enabled: true
             meterRegistryConfig.armoryRecommendedFiltersEnabled: true
 ```
-OSS community maintains [spinnaker-mixin](https://gitlab.com/uneeq-oss/spinnaker-mixin) as a collection of Grafana dashboards for the metrics exposed by Armory Observability Plugin. 
+OSS community maintains [spinnaker-mixin](https://github.com/uneeq-oss/spinnaker-mixin) as a collection of Grafana dashboards for the metrics exposed by Armory Observability Plugin. 
 
 ### Condensed NR Example
 ```yaml

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,4 +57,4 @@ spec:
     path: /aop-prometheus
 ```
 
-OSS community maintains [spinnaker-mixin](https://gitlab.com/uneeq-oss/spinnaker-mixin) as a collection of Grafana dashboards for the metrics exposed by Armory Observability Plugin. 
+OSS community maintains [spinnaker-mixin](https://github.com/uneeq-oss/spinnaker-mixin) as a collection of Grafana dashboards for the metrics exposed by Armory Observability Plugin. 


### PR DESCRIPTION
The Prometheus mixin including Grafana dashboards is now hosted on GitHub.

Part of: uneeq-oss/spinnaker-mixin#4