### PR TITLE
fix(tags): Convert all tag keys to snakeCase as expected by Prometheus standards

### DIFF
--- a/common/src/main/java/io/micrometer/prometheus/MutatedMicrometerCollector.java
+++ b/common/src/main/java/io/micrometer/prometheus/MutatedMicrometerCollector.java
@@ -46,7 +46,7 @@ class MutatedMicrometerCollector extends Collector {
             List<String> values = new ArrayList<>(tags.size());
 
             for (Tag tag : tags) {
-                keys.add(tag.getKey());
+                keys.add(NamingConvention.snakeCase.tagKey(tag.getKey()));
                 values.add(tag.getValue());
             }
 

--- a/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeEndpointFunctionalTest.java
+++ b/common/src/test/java/io/armory/plugin/observability/prometheus/PrometheusScrapeEndpointFunctionalTest.java
@@ -120,4 +120,19 @@ public class PrometheusScrapeEndpointFunctionalTest {
     String duplicate="# HELP foo_total  \n# TYPE foo_total counter ";
     assertEquals(expectedContent.length()-duplicate.length(), responseEntity.getBody().length());
   }
+
+  @Test
+  public void test_that_the_prometheus_registry_will_always_return_tags_with_snakeCase() {
+    var tags = List.of(Tag.of("my.Tag", "myValue"));
+    registry.counter("foo", tags).increment();
+    var responseEntity = sut.scrape();
+    assertTrue(responseEntity.getStatusCode().is2xxSuccessful());
+    //noinspection ConstantConditions
+    assertEquals(
+        "text/plain;version=0.0.4;charset=utf-8",
+        responseEntity.getHeaders().getContentType().toString());
+    assertTrue(responseEntity.getBody().contains("my_Tag"));
+    assertEquals(false, responseEntity.getBody().contains("my.Tag"));
+
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/armory-plugins/armory-observability-plugin/issues/63

Response after the change: 
```
# HELP cf_okhttp_requests_seconds  
# TYPE cf_okhttp_requests_seconds summary
cf_okhttp_requests_seconds_count{host="host",lib="aop",libVer="v1.4.2-SNAPSHOT",method="POST",spinSvc="clouddriver",status="IO_ERROR",target_host="host",target_port="443",target_scheme="https",uri="none",} 3.0
cf_okhttp_requests_seconds_sum{host="host",lib="aop",libVer="v1.4.2-SNAPSHOT",method="POST",spinSvc="clouddriver",status="IO_ERROR",target_host="host",target_port="443",target_scheme="https",uri="none",} 3.302209356
# HELP cf_okhttp_requests_seconds_max  
# TYPE cf_okhttp_requests_seconds_max gauge
cf_okhttp_requests_seconds_max{host="host",lib="aop",libVer="v1.4.2-SNAPSHOT",method="POST",spinSvc="clouddriver",status="IO_ERROR",target_host="host",target_port="443",target_scheme="https",uri="none",} 1.100752079
```